### PR TITLE
PVM-113: stop leaking vCenter sessions on retry/failure paths

### DIFF
--- a/pkg/controller/plan/adapter/vsphere/host.go
+++ b/pkg/controller/plan/adapter/vsphere/host.go
@@ -32,10 +32,8 @@ func (r *EsxHost) TestConnection() (err error) {
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
+	defer r.close()
 	err = r.connect(ctx)
-	if err == nil {
-		r.close()
-	}
 	return
 }
 
@@ -85,8 +83,15 @@ func (r *EsxHost) connect(ctx context.Context) (err error) {
 		SessionManager: session.NewManager(vimClient),
 		Client:         vimClient,
 	}
-	err = r.client.Login(ctx, url.User)
-	if err != nil {
+	if err = r.client.Login(ctx, url.User); err != nil {
+		// PVM-113: Login failed after vim25.NewClient already opened the
+		// SOAP/HTTP stack. Best-effort logout in case a partial session was
+		// established, release keep-alive sockets, and clear the client/finder
+		// so a half-built host can't be reused on retry.
+		_ = r.client.Logout(context.Background())
+		r.client.CloseIdleConnections()
+		r.client = nil
+		r.finder = nil
 		return liberr.Wrap(err)
 	}
 

--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -341,7 +341,17 @@ func (r *Collector) Follow(moRef interface{}, p []string, dst interface{}) error
 	if err != nil {
 		return err
 	}
-	defer client.CloseIdleConnections()
+	defer func() {
+		// PVM-113: every Login here must be paired with a Logout, otherwise
+		// each Follow call leaks a vCenter session for the lifetime of the
+		// inventory web API.
+		if logoutErr := client.Logout(context.Background()); logoutErr != nil {
+			r.log.V(1).Info(
+				"vsphere logout (Follow) failed",
+				"err", logoutErr)
+		}
+		client.CloseIdleConnections()
+	}()
 	return client.RetrieveOne(ctx, ref, p, dst)
 }
 
@@ -350,11 +360,8 @@ func (r *Collector) Test() (status int, err error) {
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
+	defer r.close()
 	status, err = r.connect(ctx)
-	if err == nil {
-		r.close()
-	}
-
 	return
 }
 
@@ -569,14 +576,14 @@ func (r *Collector) watch() (list []*libmodel.Watch) {
 // Build the client.
 func (r *Collector) connect(ctx context.Context) (status int, err error) {
 	r.close()
-	r.client, err = r.buildClient(ctx)
+	client, err := r.buildClient(ctx)
 	if err != nil {
 		if strings.Contains(err.Error(), "incorrect") && strings.Contains(err.Error(), "password") {
 			return http.StatusUnauthorized, err
 		}
 		return
 	}
-
+	r.client = client
 	return http.StatusOK, nil
 }
 
@@ -610,9 +617,16 @@ func (r *Collector) buildClient(ctx context.Context) (*govmomi.Client, error) {
 		SessionManager: session.NewManager(vimClient),
 		Client:         vimClient,
 	}
-	err = client.Login(ctx, url.User)
-	return client, err
-
+	if err = client.Login(ctx, url.User); err != nil {
+		// PVM-113: mirror govmomi.NewClient — on Login failure, best-effort
+		// Logout (in case a partial session was established) and release the
+		// underlying TCP/TLS keep-alive sockets, then return a nil client so
+		// callers cannot accidentally reference a half-built one.
+		_ = client.Logout(context.Background())
+		client.CloseIdleConnections()
+		return nil, err
+	}
+	return client, nil
 }
 
 // Close connections.


### PR DESCRIPTION
## Summary

Fixes PVM-113. The provider connect-and-retry loop and the inventory web API were leaking vCenter sessions because cleanup only ran on the success branch. Under polling/retry against an unreliable vCenter, sessions piled up indefinitely.

### Production changes (2 files)

`pkg/controller/provider/container/vsphere/collector.go`
- **`Collector.Follow`** — was `defer client.CloseIdleConnections()` only. Now also `Logout`s the session it opened. This is the headline fix: every `Follow` previously leaked one session, and it's hit by the inventory web API (`pkg/controller/provider/web/vsphere/host.go:153`) on every `?advancedOption=` query.
- **`Collector.buildClient`** — mirrors `govmomi.NewClient` semantics: on `Login` failure it best-effort `Logout`s, `CloseIdleConnections`s, and returns `(nil, err)` so callers can't reference a half-built client.
- **`Collector.connect`** — builds into a temporary and only assigns `r.client` on success (no more partial client stashed when `Login` returns an error).
- **`Collector.Test`** — switched from conditional `if err == nil { r.close() }` to `defer r.close()` (which is already nil-safe and idempotent).

`pkg/controller/plan/adapter/vsphere/host.go`
- **`EsxHost.connect`** — on `Login` failure now `Logout`s, `CloseIdleConnections`s, and clears `r.client` + `r.finder` so a half-built host can't be reused on retry.
- **`EsxHost.TestConnection`** — switched to `defer r.close()`.

Callers `pkg/forklift-api/webhooks/.../secret-admitter.go` and `pkg/controller/host/validation.go` inherit the EsxHost fix automatically.

### Out of scope (follow-up)

`pkg/controller/plan/adapter/vsphere/client.go` (`Client.connect`, `getHostClient`) has the same partial-state leak class on `Login` failure but only fires during an active migration plan, not the provider-side connection retry the Jira targets.

## Test plan

- [ ] Verify provider with bad credentials no longer accumulates sessions on the vCenter side across retries (was the primary symptom)
- [ ] Verify provider inventory polling (advanced options query) no longer accumulates sessions across calls
- [ ] Verify normal/healthy provider connect+test still works end-to-end
- [ ] Verify ESX-host TestConnection (used by host validation and the secret admitter webhook) still works on success and cleans up on auth failure

Made with [Cursor](https://cursor.com)