### PR TITLE
PEM-9121: recreate virt-v2v pod on rerun so LUKS mount is picked up

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -984,30 +984,59 @@ func (r *KubeVirt) EnsureGuestConversionPod(vm *plan.VMStatus, vmCr *VirtualMach
 		return
 	}
 
-	list, err := r.GetPodsWithLabels(r.conversionLabels(vm.Ref, true))
+	needNew, err := r.reserveConversionPodSlot(vm)
 	if err != nil {
 		return
 	}
-
-	pod := &core.Pod{}
-	if len(list.Items) == 0 {
-		pod = newPod
-		err = r.Destination.Client.Create(context.TODO(), pod)
-		if err != nil {
-			err = liberr.Wrap(err)
-			return
-		}
-		r.Log.Info(
-			"Created virt-v2v pod.",
-			"pod",
-			path.Join(
-				pod.Namespace,
-				pod.Name),
-			"vm",
-			vm.String())
+	if !needNew {
+		return
 	}
 
+	pod := newPod
+	err = r.Destination.Client.Create(context.TODO(), pod)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	r.Log.Info(
+		"Created virt-v2v pod.",
+		"pod",
+		path.Join(
+			pod.Namespace,
+			pod.Name),
+		"vm",
+		vm.String())
+
 	return
+}
+
+// reserveConversionPodSlot decides whether a new virt-v2v pod must be created
+// for the current migration attempt. If a pod already exists for THIS
+// migration (matched by migration label), no new pod is needed. Otherwise any
+// stale conversion pods left over from previous migration attempts for the
+// same plan+VM are deleted so that a fresh pod can be created with the
+// current plan spec (e.g. picking up a newly-added spec.vms[].luks.name and
+// mounting the LUKS secret at /etc/luks).
+func (r *KubeVirt) reserveConversionPodSlot(vm *plan.VMStatus) (needNew bool, err error) {
+	currentList, err := r.GetPodsWithLabels(r.conversionLabels(vm.Ref, false))
+	if err != nil {
+		return
+	}
+	if len(currentList.Items) > 0 {
+		return false, nil
+	}
+
+	staleList, err := r.GetPodsWithLabels(r.conversionLabels(vm.Ref, true))
+	if err != nil {
+		return
+	}
+	for i := range staleList.Items {
+		stale := &staleList.Items[i]
+		if err = r.DeleteObject(stale, vm, "Deleted stale guest conversion pod.", "pod"); err != nil {
+			return
+		}
+	}
+	return true, nil
 }
 
 func (r *KubeVirt) EnsureOVAVirtV2VPVCStatus(vmID string) (ready bool, err error) {

--- a/pkg/controller/plan/kubevirt_spectro_test.go
+++ b/pkg/controller/plan/kubevirt_spectro_test.go
@@ -919,6 +919,79 @@ var _ = ginkgo.Describe("kubevirt tests", func() {
 			Expect(kubevirt.DeleteObject(missing, vm, "x", "cm")).To(Succeed())
 		})
 
+		ginkgo.It("reserveConversionPodSlot should delete stale conversion pods from prior migrations and request a new one (PEM-9121)", func() {
+			kubevirt := createKubeVirtSpectro()
+			vm := &planapi.VMStatus{VM: planapi.VM{Ref: ref.Ref{ID: "vm-1", Name: "vm1"}}}
+
+			// Simulate a virt-v2v pod left over from a PREVIOUS migration
+			// attempt (different migration UID) that was created before the
+			// user added spec.vms[].luks.name to the plan — so it has the
+			// plan+VM labels but a stale migration label and no LUKS mount.
+			currentLabels := kubevirt.conversionLabels(vm.Ref, false)
+			staleLabels := map[string]string{}
+			for k, v := range currentLabels {
+				staleLabels[k] = v
+			}
+			staleLabels[kMigration] = "previous-migration"
+			stalePod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "stale-v2v",
+					Namespace: "test",
+					Labels:    staleLabels,
+				},
+				Status: v1.PodStatus{Phase: v1.PodFailed},
+			}
+			// Unrelated pod for a different VM must NOT be touched.
+			otherVMLabels := kubevirt.conversionLabels(ref.Ref{ID: "vm-2"}, false)
+			otherPod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-vm-v2v",
+					Namespace: "test",
+					Labels:    otherVMLabels,
+				},
+			}
+			Expect(kubevirt.Destination.Create(context.TODO(), stalePod)).To(Succeed())
+			Expect(kubevirt.Destination.Create(context.TODO(), otherPod)).To(Succeed())
+
+			needNew, err := kubevirt.reserveConversionPodSlot(vm)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(needNew).To(BeTrue())
+
+			// Stale pod for this VM is gone; other VM's pod is untouched.
+			Expect(kubevirt.Destination.Get(context.TODO(), types.NamespacedName{Name: "stale-v2v", Namespace: "test"}, &v1.Pod{})).ToNot(Succeed())
+			Expect(kubevirt.Destination.Get(context.TODO(), types.NamespacedName{Name: "other-vm-v2v", Namespace: "test"}, &v1.Pod{})).To(Succeed())
+		})
+
+		ginkgo.It("reserveConversionPodSlot should be a no-op when a pod already exists for the current migration", func() {
+			kubevirt := createKubeVirtSpectro()
+			vm := &planapi.VMStatus{VM: planapi.VM{Ref: ref.Ref{ID: "vm-1", Name: "vm1"}}}
+
+			currentPod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "current-v2v",
+					Namespace: "test",
+					Labels:    kubevirt.conversionLabels(vm.Ref, false),
+				},
+			}
+			Expect(kubevirt.Destination.Create(context.TODO(), currentPod)).To(Succeed())
+
+			needNew, err := kubevirt.reserveConversionPodSlot(vm)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(needNew).To(BeFalse())
+
+			// Existing pod for the current migration must survive.
+			Expect(kubevirt.Destination.Get(context.TODO(), types.NamespacedName{Name: "current-v2v", Namespace: "test"}, &v1.Pod{})).To(Succeed())
+		})
+
+		ginkgo.It("reserveConversionPodSlot should request a new pod when no conversion pod exists at all", func() {
+			kubevirt := createKubeVirtSpectro()
+			vm := &planapi.VMStatus{VM: planapi.VM{Ref: ref.Ref{ID: "vm-1", Name: "vm1"}}}
+
+			needNew, err := kubevirt.reserveConversionPodSlot(vm)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(needNew).To(BeTrue())
+		})
+
 		ginkgo.It("getPopulatorPods/DeletePopulatorPods should filter by migration label and prefix", func() {
 			kubevirt := createKubeVirtSpectro()
 			vm := &planapi.VMStatus{VM: planapi.VM{Ref: ref.Ref{ID: "vm-1"}}}


### PR DESCRIPTION
## Summary
- Fixes [PEM-9121](https://spectrocloud.atlassian.net/browse/PEM-9121): after a migration fails because `spec.vms[].luks.name` is missing, adding the LUKS secret and rerunning did not recover — the failed `virt-v2v` pod (created without the `/etc/luks` mount) was reused and the same `could not read key from user` error kept surfacing.
- `EnsureGuestConversionPod` now looks up conversion pods scoped to the current migration UID first; if none exists, it deletes any stale conversion pods for the same plan+VM from prior attempts before creating a fresh pod, so the current plan spec (including the LUKS secret volume) is applied.
- Pod-slot decision extracted into a small helper `reserveConversionPodSlot` and covered by three unit tests.

## Test plan
- [x] `go build ./pkg/controller/plan/...`
- [x] `go test ./pkg/controller/plan/ -run TestPlan -count=1` — 88/88 specs pass (3 new)
- [ ] End-to-end: create a plan with LUKS disks but no `luks.name`, start migration, wait for failure, add `luks.name` to plan, rerun, confirm a new pod is created with `/etc/luks` mounted and the migration succeeds

## Notes
- Supersedes the prior WIP on remote branch `PEM-9121` (Sharada's Feb-23 commit, no PR opened). This PR takes a broader approach — scoping the pod lookup by migration UID rather than only deleting Failed/Succeeded pods — and adds tests.
- The upstream Jira note says this can be contributed back to konveyor/forklift; happy to open that PR after this one lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PEM-9121]: https://spectrocloud.atlassian.net/browse/PEM-9121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ